### PR TITLE
Tweak ESLint rules, bump version, and minor fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Christian Oliff
+Copyright (c) 2023-2026 Christian Oliff
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -134,6 +134,7 @@ const rules = {
   "no-nested-ternary": "error",
   "no-new": "error",
   "no-new-func": "error",
+  "no-object-constructor": "error",
   "no-new-object": "error",
   "no-new-wrappers": "error",
   "no-nonoctal-decimal-escape": "error",
@@ -265,6 +266,7 @@ const rules = {
   "prefer-exponentiation-operator": "error",
   "prefer-named-capture-group": "off",
   "prefer-numeric-literals": "error",
+  "prefer-object-has-own": "error",
   "prefer-object-spread": "error",
   "prefer-promise-reject-errors": ["error", { allowEmptyReject: true }],
   "prefer-regex-literals": ["error", { disallowRedundantWrapping: true }],
@@ -308,6 +310,9 @@ const rules = {
 module.exports = [
   {
     ignores: ["**/*.min.js", "**/node_modules/**"],
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+    },
   },
   {
     files: ["eslint.config.js"],
@@ -325,6 +330,7 @@ module.exports = [
       ecmaVersion: 2022,
       sourceType: "module",
       globals: {
+        bootstrap: "readonly",
         ...globals.browser,
       },
     },

--- a/js/popover-css-inspector.js
+++ b/js/popover-css-inspector.js
@@ -686,7 +686,6 @@ function createPopovers() {
       ".popover-css-inspector[data-popper-placement='bottom'] .popover-arrow {position: fixed; left: 48%; transform: translateY(-40%); top: -5px;}" +
       "</style>";
 
-    // eslint-disable-next-line no-undef
     const popover = new bootstrap.Popover(popoverTriggerEl, {
       content,
       boundary: "window",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "popover-css-inspector",
-  "version": "1.0.0-beta17",
+  "version": "1.0.0-beta18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "popover-css-inspector",
-      "version": "1.0.0-beta17",
+      "version": "1.0.0-beta18",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popover-css-inspector",
-  "version": "1.0.0-beta17",
+  "version": "1.0.0-beta18",
   "description": "Displays CSS attributes of elements in a Bootstrap popover. Ideal for design systems and style guides.",
   "keywords": [
     "bootstrap",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/coliff/popover-css-inspector.git"
+    "url": "git+https://github.com/coliff/popover-css-inspector.git"
   },
   "funding": {
     "type": "github",
@@ -27,7 +27,8 @@
   ],
   "scripts": {
     "build": "npm run prettier && npm run lint-js && npm run minify",
-    "lint-html": "npx htmlhint index.html",
+    "lint": "npm run lint-html && npm run lint-js",
+    "lint-html": "htmlhint index.html",
     "lint-js": "eslint js/popover-css-inspector.js --fix",
     "lint-markdown": "npx markdownlint-cli .",
     "minify": "terser --ecma 5 --keep-classnames --keep-fnames --compress --mangle --output js/popover-css-inspector.min.js -- js/popover-css-inspector.js",


### PR DESCRIPTION
Add stricter ESLint rules (no-object-constructor, prefer-object-has-own), enable reportUnusedDisableDirectives, and declare bootstrap as a readonly global. Remove an inline eslint-disable in popover-js to rely on the new global. Update package.json (version bumped to 1.0.0-beta18, repository URL format, add combined lint script and update lint-html command) and update LICENSE year. These changes tighten linting, clean up lint suppressions, and prepare a new release.