### PR TITLE
Add 'ref' input to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or ref to publish (for example: v1.0.0-beta18)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -18,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.ref || github.ref }}
           persist-credentials: false
 
       - name: Setup Node.js environment
@@ -41,10 +47,12 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "release" ]; then
             tag_name="${{ github.event.release.tag_name }}"
+          elif [ -n "${{ inputs.ref }}" ]; then
+            tag_name="${{ inputs.ref }}"
           elif [ "${{ github.ref_type }}" = "tag" ]; then
             tag_name="${{ github.ref_name }}"
           else
-            echo "workflow_dispatch must be run from a version tag ref."
+            echo "workflow_dispatch must be run from a version tag ref or provided with the 'ref' input."
             exit 1
           fi
 


### PR DESCRIPTION
- Allow manual dispatch of the publish workflow from a specific tag or ref by adding an optional 'ref' input. 
- The checkout step now respects the release tag, the provided input, or the current ref, and the job sets tag_name from the release or inputs.ref. 
- Error messaging was updated to clarify that workflow_dispatch requires a tag ref or the 'ref' input.