### PR TITLE
Store package metadata in variables

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,11 @@ jobs:
       - name: Resolve package metadata
         id: package
         run: |
-          echo "name=$(node -p 'require(\"./package.json\").name')" >> "$GITHUB_OUTPUT"
-          echo "version=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+          package_name=$(node -p "require('./package.json').name")
+          package_version=$(node -p "require('./package.json').version")
+
+          echo "name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
 
       - name: Resolve release tag
         id: release


### PR DESCRIPTION
Assign package name and version to shell variables before writing to GITHUB_OUTPUT instead of inlining node commands. This improves readability, avoids repeating node calls, and reduces risk of quoting/escaping issues when exporting values for subsequent workflow steps.