### PR TITLE
Refactor build banner sync; update globs & year

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -336,7 +336,7 @@ module.exports = [
     },
   },
   {
-    files: ["**/*.js"],
+    files: ["js/**/*.js"],
     languageOptions: {
       ecmaVersion,
       sourceType: "module",
@@ -348,7 +348,7 @@ module.exports = [
   },
   js.configs.recommended,
   {
-    files: ["**/*.js", "**/*.cjs"],
+    files: ["js/**/*.js", "**/*.cjs", "eslint.config.js"],
     rules,
   },
   {

--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
       <footer>
         <p class="mt-4">
           <a href="https://github.com/coliff/popover-css-inspector" target="_blank" rel="noopener" class="opacity-75 text-decoration-none small text-secondary">
-            &copy; 2025 Christian Oliff
+            &copy; 2026 Christian Oliff
           </a>
         </p>
       </footer>

--- a/scripts/build.cjs
+++ b/scripts/build.cjs
@@ -10,29 +10,26 @@ const ecma = typeof ecmaVersion === "number" ? ecmaVersion : 2022;
 const srcPath = path.join(root, "js", "popover-css-inspector.js");
 const outPath = path.join(root, "js", "popover-css-inspector.min.js");
 
-function syncBannerVersion() {
-  const code = fs.readFileSync(srcPath, "utf8");
+/**
+ * Returns source with the license banner `v…` aligned to package.json `version`.
+ * Does not read or write the filesystem.
+ */
+function withSyncedBanner(code) {
   if (!/\*\s*Popover CSS Inspector\s+v[\d\w.-]+/.test(code)) {
     throw new Error(
       `Expected a license banner line matching "* Popover CSS Inspector v…" in ${path.relative(root, srcPath)}`,
     );
   }
-  const next = code.replace(
+  return code.replace(
     /(\*\s*Popover CSS Inspector\s+)v[\d\w.-]+/,
     `$1v${version}`,
   );
-  if (next === code) {
-    return;
-  }
-  fs.writeFileSync(srcPath, next);
-  console.log(
-    `Updated banner in ${path.relative(root, srcPath)} to v${version}`,
-  );
 }
 
-async function minify() {
-  const code = fs.readFileSync(srcPath, "utf8");
-  const result = await terser.minify(code, {
+async function main() {
+  const original = fs.readFileSync(srcPath, "utf8");
+  const sourceForMinify = withSyncedBanner(original);
+  const result = await terser.minify(sourceForMinify, {
     ecma,
     compress: true,
     mangle: true,
@@ -43,11 +40,12 @@ async function minify() {
     throw result.error;
   }
   fs.writeFileSync(outPath, result.code);
-}
-
-async function main() {
-  syncBannerVersion();
-  await minify();
+  if (sourceForMinify !== original) {
+    fs.writeFileSync(srcPath, sourceForMinify);
+    console.log(
+      `Updated banner in ${path.relative(root, srcPath)} to v${version}`,
+    );
+  }
 }
 
 main().catch((failure) => {


### PR DESCRIPTION
- Restrict ESLint JS globs to js/**/*.js and include eslint.config.js in the rules set. 
- Bump site footer copyright from 2025 to 2026.
- Refactor scripts/build.cjs: replace syncBannerVersion with a pure withSyncedBanner(code) that returns the banner-updated source (no FS side effects), use that source for minification, and only write back the updated source file and log when the banner actually changed.